### PR TITLE
add version for fastctl

### DIFF
--- a/pkg/fastctl/fastctl.go
+++ b/pkg/fastctl/fastctl.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fast-io/fast/pkg/fastctl/clusterpodips"
 	"github.com/fast-io/fast/pkg/fastctl/localdev"
 	"github.com/fast-io/fast/pkg/fastctl/localpodips"
+	"github.com/fast-io/fast/pkg/fastctl/version"
 )
 
 func NewFastCtlCommand(rootCmd string) *cobra.Command {
@@ -34,6 +35,7 @@ func NewFastCtlCommand(rootCmd string) *cobra.Command {
 		},
 	}
 	groups.Add(cmd)
+	cmd.AddCommand(version.NewCmdVersion(rootCmd))
 	templates.ActsAsRootCommand(cmd, []string{"options"}, groups...)
 
 	return cmd

--- a/pkg/fastctl/version/version.go
+++ b/pkg/fastctl/version/version.go
@@ -1,0 +1,35 @@
+package version
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/fast-io/fast/pkg/version"
+)
+
+var (
+	versionShort   = `Print the version information`
+	versionLong    = `Print the version information.`
+	versionExample = templates.Examples(`
+		# Print %[1]s command version
+		%[1]s version`)
+)
+
+// NewCmdVersion prints out the release version info for this command binary.
+// It is used as a subcommand of a parent command.
+func NewCmdVersion(name string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "version",
+		Short:   versionShort,
+		Long:    versionLong,
+		Example: fmt.Sprintf(versionExample, name),
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintf(os.Stdout, "%s version: %s\n", name, version.Get())
+		},
+	}
+
+	return cmd
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
